### PR TITLE
Standardize web component prefix to 'ui-'

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A reactive template binding system and web component toolkit for rapid HTML prot
 - ⚡ **Reactive bindings** - Powered by Vue 3's reactivity system
 - 🎯 **Declarative syntax** - Vue/Angular-inspired template bindings
 - 🧩 **Web Components** - Build reusable custom elements
-- 📦 **Component loading** - Include HTML components with `<wck-include>`
+- 📦 **Component loading** - Include HTML components with `<ui-include>`
 - 🎨 **Icon system** - Beautiful Lucide icons out of the box
 
 ## Installation
@@ -136,12 +136,12 @@ import { bindTemplate, reactive } from "@chriscalo/web-component-kit";
 
 ## Component Loading
 
-Include HTML component files using the `<wck-include>` directive:
+Include HTML component files using the `<ui-include>` directive:
 
 ```html
 <!-- main.html -->
-<wck-include src="./my-component.html"></wck-include>
-<wck-include src="./ui-icon.component.html"></wck-include>
+<ui-include src="./my-component.html"></ui-include>
+<ui-include src="./ui-icon.component.html"></ui-include>
 ```
 
 Components are automatically loaded and injected into the document.
@@ -152,7 +152,7 @@ The kit includes a powerful icon component using Lucide icons:
 
 ```html
 <!-- Include the icon component -->
-<wck-include src="node_modules/@chriscalo/web-component-kit/ui-icon.component.html"></wck-include>
+<ui-include src="node_modules/@chriscalo/web-component-kit/ui-icon.component.html"></ui-include>
 
 <!-- Use icons -->
 <ui-icon name="home"></ui-icon>
@@ -202,7 +202,7 @@ await loadComponent("./my-component.html");
 
 #### `processIncludes()`
 
-Processes all `<wck-include>` elements in the document.
+Processes all `<ui-include>` elements in the document.
 
 ```javascript
 await processIncludes();
@@ -275,7 +275,7 @@ Create reusable components in separate HTML files:
 Use it in your app:
 
 ```html
-<wck-include src="./my-counter.component.html"></wck-include>
+<ui-include src="./my-counter.component.html"></ui-include>
 <my-counter></my-counter>
 ```
 

--- a/index.js
+++ b/index.js
@@ -891,9 +891,9 @@ export async function loadComponent(url) {
   await Promise.all(scriptPromises);
 }
 
-// Process wck-include directives in the document
+// Process ui-include directives in the document
 export async function processIncludes() {
-  const includes = document.querySelectorAll("wck-include[src]");
+  const includes = document.querySelectorAll("ui-include[src]");
   const promises = [];
   
   for (const include of includes) {

--- a/ui-icon.test.html
+++ b/ui-icon.test.html
@@ -48,7 +48,7 @@
   <div id="icon-demos"></div>
   
   <!-- Include the ui-icon component -->
-  <wck-include src="./ui-icon.component.html"></wck-include>
+  <ui-include src="./ui-icon.component.html"></ui-include>
   
   <script type="module">
     import { componentsReady, processIncludes } from "./index.js";


### PR DESCRIPTION
## Summary
- Standardized all web component prefixes to use consistent `ui-` naming convention
- Changed `wck-include` to `ui-include` throughout the codebase
- All tests passing successfully

## Changes
- Updated `index.js` processIncludes function to look for `ui-include` elements
- Updated all documentation examples in README.md to use `ui-include`
- Updated test files to use the new `ui-include` syntax

## Test Results
✅ All tests pass:
- Core library tests: 9/9 passed
- UI icon component tests: 7/7 passed

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)